### PR TITLE
Update all Polldaddy text & link references to Crowdsignal

### DIFF
--- a/polldaddy-org.php
+++ b/polldaddy-org.php
@@ -35,7 +35,7 @@ class WPORG_Polldaddy extends WP_Polldaddy {
 			$this->rating_user_code = get_option( 'pd-rating-usercode' );
 
 			if ( empty( $this->rating_user_code ) ) {
-				$this->log( 'set_api_user_code: retrieve usercode from Polldaddy' );
+				$this->log( 'set_api_user_code: retrieve usercode from Crowdsignal' );
 				$polldaddy = $this->get_client( WP_POLLDADDY__PARTNERGUID );
 				$polldaddy->reset();
 
@@ -152,7 +152,7 @@ class WPORG_Polldaddy extends WP_Polldaddy {
 		$polldaddy_email    = stripslashes( $_POST['polldaddy_email'] );
 		$polldaddy_password = stripslashes( $_POST['polldaddy_password'] );
 
-		$this->log( 'api_key_page_load: get Polldaddy API key for account - '.$polldaddy_email );
+		$this->log( 'api_key_page_load: get Crowdsignal API key for account - '.$polldaddy_email );
 
 		if ( !$polldaddy_email )
 			$this->errors->add( 'polldaddy_email', __( 'Email address required', 'polldaddy' ) );
@@ -190,8 +190,8 @@ class WPORG_Polldaddy extends WP_Polldaddy {
 			}
 			$response_code = wp_remote_retrieve_response_code( $polldaddy_api_key );
 			if ( 200 != $response_code ) {
-				$this->log( 'management_page_load: could not connect to Polldaddy API key service' );
-				$this->errors->add( 'http_code', __( 'Could not connect to Polldaddy API Key service', 'polldaddy' ) );
+				$this->log( 'management_page_load: could not connect to Crowdsignal API key service' );
+				$this->errors->add( 'http_code', __( 'Could not connect to Crowdsignal API Key service', 'polldaddy' ) );
 				return false;
 			}
 			$polldaddy_api_key = wp_remote_retrieve_body( $polldaddy_api_key );
@@ -205,8 +205,8 @@ class WPORG_Polldaddy extends WP_Polldaddy {
 			);
 
 			if ( !$fp ) {
-				$this->log( 'management_page_load: could not connect to Polldaddy API key service' );
-				$this->errors->add( 'connect', __( "Can't connect to Polldaddy.com", 'polldaddy' ) );
+				$this->log( 'management_page_load: could not connect to Crowdsignal API key service' );
+				$this->errors->add( 'connect', __( "Can't connect to Crowdsignal.com", 'polldaddy' ) );
 				return false;
 			}
 
@@ -235,11 +235,11 @@ class WPORG_Polldaddy extends WP_Polldaddy {
 		if ( isset( $polldaddy_api_key ) && strlen( $polldaddy_api_key ) > 0 ) {
 			update_option( 'polldaddy_api_key', $polldaddy_api_key );
 		} else {
-			$this->log( 'management_page_load: login to Polldaddy failed' );
-			$this->errors->add( 'polldaddy_api_key', __( 'Login to Polldaddy failed.  Double check your email address and password.', 'polldaddy' ) );
+			$this->log( 'management_page_load: login to Crowdsignal failed' );
+			$this->errors->add( 'polldaddy_api_key', __( 'Login to Crowdsignal failed.  Double check your email address and password.', 'polldaddy' ) );
 			if ( 1 !== $this->use_ssl ) {
 				$this->errors->add( 'polldaddy_api_key', __( 'If your email address and password are correct, your host may not support secure logins.', 'polldaddy' ) );
-				$this->errors->add( 'polldaddy_api_key', __( 'In that case, you may be able to log in to Polldaddy by unchecking the "Use SSL to Log in" checkbox.', 'polldaddy' ) );
+				$this->errors->add( 'polldaddy_api_key', __( 'In that case, you may be able to log in to Crowdsignal by unchecking the "Use SSL to Log in" checkbox.', 'polldaddy' ) );
 				$this->use_ssl = 0;
 			}
 			update_option( 'polldaddy_use_ssl', $this->use_ssl );
@@ -250,7 +250,7 @@ class WPORG_Polldaddy extends WP_Polldaddy {
 		$polldaddy->reset();
 		if ( !$polldaddy->get_usercode( $this->id ) ) {
 			$this->parse_errors( $polldaddy );
-			$this->log( 'management_page_load: get usercode from Polldaddy failed' );
+			$this->log( 'management_page_load: get usercode from Crowdsignal failed' );
 			$this->errors->add( 'GetUserCode', __( 'Account could not be accessed.  Are your email address and password correct?', 'polldaddy' ) );
 			return false;
 		}
@@ -265,16 +265,16 @@ class WPORG_Polldaddy extends WP_Polldaddy {
 
 <div class="wrap">
 
-	<h2><?php _e( 'Polldaddy Account', 'polldaddy' ); ?></h2>
+	<h2><?php _e( 'Crowdsignal Account', 'polldaddy' ); ?></h2>
 
-	<p><?php printf( __( 'Before you can use the Polldaddy plugin, you need to enter your <a href="%s">Polldaddy.com</a> account details.', 'polldaddy' ), 'http://polldaddy.com/' ); ?></p>
+	<p><?php printf( __( 'Before you can use the Crowdsignal plugin, you need to enter your <a href="%s">Crowdsignal.com</a> account details.', 'polldaddy' ), 'https://app.crowdsignal.com/' ); ?></p>
 
 	<form action="" method="post">
 		<table class="form-table">
 			<tbody>
 				<tr class="form-field form-required">
 					<th valign="top" scope="row">
-						<label for="polldaddy-email"><?php _e( 'Polldaddy Email Address', 'polldaddy' ); ?></label>
+						<label for="polldaddy-email"><?php _e( 'Crowdsignal Email Address', 'polldaddy' ); ?></label>
 					</th>
 					<td>
 						<input type="text" name="polldaddy_email" id="polldaddy-email" aria-required="true" size="40" value="<?php if ( isset( $_POST['polldaddy_email'] ) ) echo esc_attr( $_POST['polldaddy_email'] ); ?>" />
@@ -282,7 +282,7 @@ class WPORG_Polldaddy extends WP_Polldaddy {
 				</tr>
 				<tr class="form-field form-required">
 					<th valign="top" scope="row">
-						<label for="polldaddy-password"><?php _e( 'Polldaddy Password', 'polldaddy' ); ?></label>
+						<label for="polldaddy-password"><?php _e( 'Crowdsignal Password', 'polldaddy' ); ?></label>
 					</th>
 					<td>
 						<input type="password" name="polldaddy_password" id="polldaddy-password" aria-required="true" size="40" />
@@ -299,7 +299,7 @@ class WPORG_Polldaddy extends WP_Polldaddy {
 					</th>
 					<td>
 						<input type="checkbox" name="polldaddy_use_ssl" id="polldaddy-use-ssl" value="1" <?php echo $checked ?> style="width: auto"/>
-						<label for="polldaddy-use-ssl"><?php _e( 'This ensures a secure login to your Polldaddy account.  Only uncheck if you are having problems logging in.', 'polldaddy' ); ?></label>
+						<label for="polldaddy-use-ssl"><?php _e( 'This ensures a secure login to your Crowdsignal account.  Only uncheck if you are having problems logging in.', 'polldaddy' ); ?></label>
 						<input type="hidden" name="polldaddy_use_ssl_checkbox" value="1" />
 					</td>
 				</tr>
@@ -341,19 +341,19 @@ class WPORG_Polldaddy extends WP_Polldaddy {
     <td>
       <input type="checkbox" name="polldaddy-load-poll-inline" id="polldaddy-load-poll-inline" value="1" <?php echo $inline ?> style="width: auto" />
         <span class="description">
-          <label for="polldaddy-load-poll-inline"><?php _e( 'This will load the Polldaddy shortcodes inline rather than in the page footer.', 'polldaddy' ); ?></label>
+          <label for="polldaddy-load-poll-inline"><?php _e( 'This will load the Crowdsignal shortcodes inline rather than in the page footer.', 'polldaddy' ); ?></label>
         </span>
     </td>
   </tr><tr class="form-field form-required">
     <th valign="top" scope="row">
       <label for="polldaddy-multiple-accounts">
-        <?php _e( 'Multiple Polldaddy Accounts', 'polldaddy' ); ?>
+        <?php _e( 'Multiple Crowdsignal Accounts', 'polldaddy' ); ?>
       </label>
     </th>
     <td>
       <input type="checkbox" name="polldaddy-multiple-accounts" id="polldaddy-multiple-accounts" value="1" <?php echo $checked ?> style="width: auto" />
         <span class="description">
-          <label for="polldaddy-multiple-accounts"><?php _e( 'This setting will allow each blog user to import a Polldaddy account.', 'polldaddy' ); ?></label>
+          <label for="polldaddy-multiple-accounts"><?php _e( 'This setting will allow each blog user to import a Crowdsignal account.', 'polldaddy' ); ?></label>
         </span>
     </td>
   </tr>
@@ -366,7 +366,7 @@ class WPORG_Polldaddy extends WP_Polldaddy {
     <td>
       <input type="checkbox" name="polldaddy-sync-account" id="polldaddy-sync-account" value="1" style="width: auto" />
         <span class="description">
-          <label for="polldaddy-sync-account"><?php _e( 'This will synchronize your ratings Polldaddy account.', 'polldaddy' ); ?></label>
+          <label for="polldaddy-sync-account"><?php _e( 'This will synchronize your ratings Crowdsignal account.', 'polldaddy' ); ?></label>
         </span>
     </td>
   </tr>
@@ -1102,7 +1102,7 @@ function polldaddy_login_warning() {
 	global $cache_enabled, $hook_suffix;
 	$page = isset( $_GET[ 'page' ] ) ? $_GET[ 'page' ] : '';
 	if ( ( $hook_suffix == 'plugins.php' || $page == 'polls' ) && false == get_option( 'polldaddy_api_key' ) && function_exists( "admin_url" ) )
-		echo '<div class="updated"><p><strong>' . sprintf( __( 'Warning! The Polldaddy plugin must be linked to your Polldaddy.com account. Please visit the <a href="%s">plugin settings page</a> to login.', 'polldaddy' ), admin_url( 'options-general.php?page=polls&action=options' ) ) . '</strong></p></div>';
+		echo '<div class="updated"><p><strong>' . sprintf( __( 'Warning! The Crowdsignal plugin must be linked to your Crowdsignal.com account. Please visit the <a href="%s">plugin settings page</a> to login.', 'polldaddy' ), admin_url( 'options-general.php?page=polls&action=options' ) ) . '</strong></p></div>';
 }
 add_action( 'admin_notices', 'polldaddy_login_warning' );
 

--- a/polldaddy.php
+++ b/polldaddy.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * Plugin Name: Polldaddy Polls & Ratings
+ * Plugin Name: Crowdsignal Polls & Ratings
  * Plugin URI: http://wordpress.org/extend/plugins/polldaddy/
- * Description: Create and manage Polldaddy polls and ratings in WordPress
+ * Description: Create and manage Crowdsignal polls and ratings in WordPress
  * Author: Automattic, Inc.
- * Author URL: http://polldaddy.com/
+ * Author URL: https://crowdsignal.com/
  * Version: 2.0.37
  */
 
@@ -316,16 +316,16 @@ class WP_Polldaddy {
 ?>
 
 <div class="wrap">
-	<h2 id="polldaddy-header"><?php _e( 'Polldaddy', 'polldaddy' ); ?></h2>
+	<h2 id="polldaddy-header"><?php _e( 'Crowdsignal', 'polldaddy' ); ?></h2>
 
-	<p><?php printf( __( 'Before you can use the Polldaddy plugin, you need to enter your <a href="%s">Polldaddy.com</a> account details.', 'polldaddy' ), 'http://polldaddy.com/' ); ?></p>
+	<p><?php printf( __( 'Before you can use the Crowdsignal plugin, you need to enter your <a href="%s">Crowdsignal.com</a> account details.', 'polldaddy' ), 'https://app.crowdsignal.com/' ); ?></p>
 
 	<form action="" method="post">
 		<table class="form-table">
 			<tbody>
 				<tr class="form-field form-required">
 					<th valign="top" scope="row">
-						<label for="polldaddy-email"><?php _e( 'Polldaddy Email Address', 'polldaddy' ); ?></label>
+						<label for="polldaddy-email"><?php _e( 'Crowdsignal Email Address', 'polldaddy' ); ?></label>
 					</th>
 					<td>
 						<input type="text" name="polldaddy_email" id="polldaddy-email" aria-required="true" size="40" />
@@ -333,7 +333,7 @@ class WP_Polldaddy {
 				</tr>
 				<tr class="form-field form-required">
 					<th valign="top" scope="row">
-						<label for="polldaddy-password"><?php _e( 'Polldaddy Password', 'polldaddy' ); ?></label>
+						<label for="polldaddy-password"><?php _e( 'Crowdsignal Password', 'polldaddy' ); ?></label>
 					</th>
 					<td>
 						<input type="password" name="polldaddy_password" id="polldaddy-password" aria-required="true" size="40" />
@@ -517,7 +517,7 @@ class WP_Polldaddy {
 					}
 				}
 				if ( isset( $_POST[ 'email' ] ) )
-					wp_mail( $current_user->user_email, "Polldaddy Settings", $msg );
+					wp_mail( $current_user->user_email, "Crowdsignal Settings", $msg );
 				update_option( 'polldaddy_settings', $settings );
 				break;
 			case 'restore-account' : // restore everything
@@ -1354,16 +1354,16 @@ class WP_Polldaddy {
 
 		<h2 id="poll-list-header"><?php
 				if ( $this->is_author )
-					printf( __( 'Polldaddy Polls <a href="%s" class="add-new-h2">Add New</a>', 'polldaddy' ), esc_url( add_query_arg( array( 'action' => 'create-poll', 'poll' => false, 'message' => false ) ) ) );
+					printf( __( 'Crowdsignal Polls <a href="%s" class="add-new-h2">Add New</a>', 'polldaddy' ), esc_url( add_query_arg( array( 'action' => 'create-poll', 'poll' => false, 'message' => false ) ) ) );
 				else
-					_e( 'Polldaddy Polls ', 'polldaddy' );
+					_e( 'Crowdsignal Polls ', 'polldaddy' );
 		?></h2><?php
 				$polldaddy = $this->get_client( WP_POLLDADDY__PARTNERGUID, $this->user_code );
 				$account = $polldaddy->get_account();
 				if ( !empty( $account ) )
 					$account_email = esc_attr( $account->email );
 				if ( isset( $account_email ) && current_user_can( 'manage_options' ) ) {
-					echo "<p>" . sprintf( __( 'Linked to WordPress.com Account: <strong>%s</strong> (<a target="_blank" href="options-general.php?page=polls&action=options">Settings</a> / <a target="_blank" href="http://polldaddy.com/dashboard/">Polldaddy.com</a>)', 'polldaddy' ), $account_email ) . "</p>";
+					echo "<p>" . sprintf( __( 'Linked to WordPress.com Account: <strong>%s</strong> (<a target="_blank" href="options-general.php?page=polls&action=options">Settings</a> / <a target="_blank" href="https://app.crowdsignal.com/">Crowdsignal.com</a>)', 'polldaddy' ), $account_email ) . "</p>";
 				}
 
 				if ( !isset( $_GET['view'] ) )
@@ -2206,7 +2206,7 @@ src="http://static.polldaddy.com/p/<?php echo (int) $poll_id; ?>.js"&gt;&lt;/scr
 		<div class="inside">
 
 			<ul class="pd-tabs">
-				<li class="selected" id="pd-styles"><a href="#"><?php _e( 'Polldaddy Styles', 'polldaddy' ); ?></a><input type="checkbox" style="display:none;" id="regular"/></li>
+				<li class="selected" id="pd-styles"><a href="#"><?php _e( 'Crowdsignal Styles', 'polldaddy' ); ?></a><input type="checkbox" style="display:none;" id="regular"/></li>
 				<?php $hide = $show_custom == true ? ' style="display:block;"' : ' style="display:none;"'; ?>
 				<li id="pd-custom-styles" <?php echo $hide; ?>><a href="#"><?php _e( 'Custom Styles', 'polldaddy' ); ?></a><input type="checkbox" style="display:none;" id="custom"/></li>
 
@@ -2293,7 +2293,7 @@ src="http://static.polldaddy.com/p/<?php echo (int) $poll_id; ?>.js"&gt;&lt;/scr
 									<th class="cb">
 
 										<input type="radio" name="styleTypeCB" id="regular" onclick="javascript:pd_build_styles( 0 );"/>
-										<label for="skin" onclick="javascript:pd_build_styles( 0 );"><?php _e( 'Polldaddy Style', 'polldaddy' ); ?></label>
+										<label for="skin" onclick="javascript:pd_build_styles( 0 );"><?php _e( 'Crowdsignal Style', 'polldaddy' ); ?></label>
 
 										<?php $disabled = $show_custom == false ? ' disabled="true"' : ''; ?>
 
@@ -2384,7 +2384,7 @@ src="http://static.polldaddy.com/p/<?php echo (int) $poll_id; ?>.js"&gt;&lt;/scr
 					<div id="styleIDErr" class="formErr" style="display:none;"><?php _e( 'Please choose a style.', 'polldaddy' ); ?></div>
 					<?php else : ?>
 					<p><?php _e( 'You currently have no custom styles created.', 'polldaddy' ); ?> <a href="/wp-admin/edit.php?page=polls&amp;action=create-style" class="add-new-h2"><?php _e( 'New Style', 'polldaddy');?></a></p>
-					<p><?php printf( __( 'Did you know we have a new editor for building your own custom poll styles? Find out more <a href="%s" target="_blank">here</a>.', 'polldaddy' ), 'http://support.polldaddy.com/custom-poll-styles/' ); ?></p>
+					<p><?php printf( __( 'Did you know we have a new editor for building your own custom poll styles? Find out more <a href="%s" target="_blank">here</a>.', 'polldaddy' ), 'https://crowdsignal.com/support/custom-poll-styles/' ); ?></p>
 					<?php endif; ?>
 				</div>
 
@@ -2981,7 +2981,7 @@ src="http://static.polldaddy.com/p/<?php echo (int) $poll_id; ?>.js"&gt;&lt;/scr
 														</td>
 													</tr>
 													<tr>
-														<td><?php _e( 'Image URL', 'polldaddy' ); ?>: <a href="http://support.polldaddy.com/custom-poll-styles/" class="noteLink" title="<?php _e( 'Click here for more information', 'polldaddy' ); ?>">(?)</a></td>
+														<td><?php _e( 'Image URL', 'polldaddy' ); ?>: <a href="https://crowdsignal.com/support/custom-poll-styles/" class="noteLink" title="<?php _e( 'Click here for more information', 'polldaddy' ); ?>">(?)</a></td>
 														<td>
 															<input type="text" id="background-image" onblur="bind(this);"/>
 														</td>
@@ -3431,7 +3431,7 @@ src="http://static.polldaddy.com/p/<?php echo (int) $poll_id; ?>.js"&gt;&lt;/scr
 	<!-- Scale Table -->
 												<table class="CSSE_edit" id="editScale" style="display:none;">
 													<tr>
-														<td width="85"><?php _e( 'Width', 'polldaddy' ); ?> (px):  <a href="http://support.polldaddy.com/custom-poll-styles/" class="noteLink" title="<?php _e( 'Click here for more information', 'polldaddy' ); ?>">(?)</a></td>
+														<td width="85"><?php _e( 'Width', 'polldaddy' ); ?> (px):  <a href="https://crowdsignal.com/support/custom-poll-styles/" class="noteLink" title="<?php _e( 'Click here for more information', 'polldaddy' ); ?>">(?)</a></td>
 														<td>
 															<input type="text" maxlength="4" class="elmColor" id="width" onblur="bind(this);"/>
 														</td>
@@ -3761,7 +3761,7 @@ src="http://static.polldaddy.com/p/<?php echo (int) $poll_id; ?>.js"&gt;&lt;/scr
 						$rating_errors[] = $polldaddy->errors;
 					}
 				} elseif ( isset( $polldaddy->errors[ -1 ] ) && $polldaddy->errors[ -1 ] == "Can't connect" ) {
-					$this->contact_support_message( __( 'Could not connect to the Polldaddy API' ), $rating_errors );
+					$this->contact_support_message( __( 'Could not connect to the Crowdsignal API' ), $rating_errors );
 					$error = true;
 				} elseif ( isset( $polldaddy->errors[ -1 ] ) && $polldaddy->errors[ -1 ] == "Invalid API URL" ) {
 					$this->contact_support_message( __( 'The API URL is incorrect' ), $rating_errors );
@@ -4968,17 +4968,17 @@ src="http://static.polldaddy.com/p/<?php echo (int) $poll_id; ?>.js"&gt;&lt;/scr
   </h2>
 	<?php if ( $this->is_admin || $this->multiple_accounts ) { ?>
 		<h3>
-			<?php _e( 'Polldaddy Account Info', 'polldaddy' ); ?>
+			<?php _e( 'Crowdsignal Account Info', 'polldaddy' ); ?>
 		</h3>
-		<p><?php _e( '<em>Polldaddy</em> and <em>WordPress.com</em> are now connected using <a href="http://en.support.wordpress.com/wpcc-faq/">WordPress.com Connect</a>. If you have a WordPress.com account you can use it to login to <a href="http://polldaddy.com/">Polldaddy.com</a>. Click on the Polldaddy "sign in" button, authorize the connection and create your new Polldaddy account.', 'polldaddy' ); ?></p>
-		<p><?php _e( 'Login to the Polldaddy website and scroll to the end of your <a href="http://polldaddy.com/account/#apikey">account page</a> to create or retrieve an API key.', 'polldaddy' ); ?></p>
+		<p><?php _e( '<em>Crowdsignal</em> and <em>WordPress.com</em> are now connected using <a href="http://en.support.wordpress.com/wpcc-faq/">WordPress.com Connect</a>. If you have a WordPress.com account you can use it to login to <a href="https://app.crowdsignal.com/">Crowdsignal.com</a>. Click on the Crowdsignal "sign in" button, authorize the connection and create your new Crowdsignal account.', 'polldaddy' ); ?></p>
+		<p><?php _e( 'Login to the Crowdsignal website and scroll to the end of your <a href="https://app.crowdsignal.com/account/#apikey">account page</a> to create or retrieve an API key.', 'polldaddy' ); ?></p>
 		<?php if ( isset( $account_email ) && $account_email != false ) { ?>
 			<p><?php printf( __( 'Your account is currently linked to this API key: <strong>%s</strong>', 'polldaddy' ), WP_POLLDADDY__PARTNERGUID ); ?></p>
 			<br />
-			<h3><?php _e( 'Link to a different Polldaddy account', 'polldaddy' ); ?></h3>
+			<h3><?php _e( 'Link to a different Crowdsignal account', 'polldaddy' ); ?></h3>
 		<?php } else { ?>
 			<br />
-			<h3><?php _e( 'Link to your Polldaddy account', 'polldaddy' ); ?></h3>
+			<h3><?php _e( 'Link to your Crowdsignal account', 'polldaddy' ); ?></h3>
 		<?php } ?>
   <form action="" method="post">
     <table class="form-table">
@@ -4986,7 +4986,7 @@ src="http://static.polldaddy.com/p/<?php echo (int) $poll_id; ?>.js"&gt;&lt;/scr
         <tr class="form-field form-required">
           <th valign="top" scope="row">
             <label for="polldaddy-key">
-              <?php _e( 'Polldaddy.com API Key', 'polldaddy' ); ?>
+              <?php _e( 'Crowdsignal.com API Key', 'polldaddy' ); ?>
             </label>
           </th>
           <td>
@@ -5108,7 +5108,7 @@ if ( false == is_object( $poll ) ) {
 	}
 	if ( $show_reset_form ) {
 		echo "<h3>" . __( 'Reset Connection Settings', 'polldaddy' ) . "</h3>";
-		echo "<p>" . __( 'If you are experiencing problems connecting to the Polldaddy website resetting your connection settings may help. A backup will be made. After resetting, link your account again with the same API key.', 'polldaddy' ) . "</p>";
+		echo "<p>" . __( 'If you are experiencing problems connecting to the Crowdsignal website resetting your connection settings may help. A backup will be made. After resetting, link your account again with the same API key.', 'polldaddy' ) . "</p>";
 		echo "<p>" . __( 'The following settings will be reset:', 'polldaddy' ) . "</p>";
 		echo "<table>";
 		foreach( $settings as $key => $value ) {
@@ -5116,7 +5116,7 @@ if ( false == is_object( $poll ) ) {
 				if ( strpos( $key, 'usercode' ) )
 					$value = "***********" . substr( $value, -4 );
 				elseif ( in_array( $key, array( 'pd-rating-pages-id', 'pd-rating-comments-id', 'pd-rating-posts-id' ) ) )
-					$value = "$value (<a href='http://polldaddy.com/ratings/{$value}/edit/'>" . __( 'Edit', 'polldaddy' ) . "</a>)";
+					$value = "$value (<a href='https://app.crowdsignal.com/ratings/{$value}/edit/'>" . __( 'Edit', 'polldaddy' ) . "</a>)";
 				echo "<tr><th style='text-align: right'>$key:</th><td>$value</td></tr>\n";
 			}
 		}
@@ -5145,7 +5145,7 @@ if ( false == is_object( $poll ) ) {
 				if ( strpos( $key, 'usercode' ) )
 					$value = "***********" . substr( $value, -4 );
 				elseif ( in_array( $key, array( 'pd-rating-pages-id', 'pd-rating-comments-id', 'pd-rating-posts-id' ) ) )
-					$value = "$value (<a href='http://polldaddy.com/ratings/{$value}/edit/'>" . __( 'Edit', 'polldaddy' ) . "</a>)";
+					$value = "$value (<a href='https://app.crowdsignal.com/ratings/{$value}/edit/'>" . __( 'Edit', 'polldaddy' ) . "</a>)";
 				echo "<tr><th style='text-align: right'>$key:</th><td>$value</td></tr>\n";
 			}
 		}
@@ -5165,7 +5165,7 @@ if ( false == is_object( $poll ) ) {
 		if ( $show_reset_form && isset( $settings[ 'pd-rating-posts-id' ] ) && $settings[ 'pd-rating-posts-id' ] != $previous_settings[ 'pd-rating-posts-id' ] ) {
 			echo "<h3>" . __( 'Restore Ratings Settings', 'polldaddy' ) . "</h3>";
 			echo "<p>" . __( 'Different rating settings detected. If you are missing ratings on your posts, pages or comments you can restore the original rating settings by clicking the button below.', 'polldaddy' ) . "</p>";
-			echo "<p>" . __( 'This tells the plugin to look for this data in a different rating in your Polldaddy account.', 'polldaddy' ) . "</p>";
+			echo "<p>" . __( 'This tells the plugin to look for this data in a different rating in your Crowdsignal account.', 'polldaddy' ) . "</p>";
 			?>
 			<form action="" method="post">
 				<p class="submit">
@@ -5230,9 +5230,9 @@ if ( false == is_object( $poll ) ) {
 		echo '<div class="error" id="polldaddy">';
 		echo '<h1>' . $message . '</h1>';
 		echo '<p>' . __( "There are a few things you can do:" );
-		echo "<ul><ol>" . __( "Press reload on your browser and reload this page. There may have been a temporary problem communicating with Polldaddy.com", "polldaddy" ) . "</ol>";
+		echo "<ul><ol>" . __( "Press reload on your browser and reload this page. There may have been a temporary problem communicating with Crowdsignal.com", "polldaddy" ) . "</ol>";
 		echo "<ol>" . sprintf( __( "Go to the <a href='%s'>poll settings page</a>, scroll to the end of the page and reset your connection settings. Link your account again with the same API key.", "polldaddy" ), 'options-general.php?page=polls&action=options' ) . "</ol>";
-		echo "<ol>" . sprintf( __( 'Contact <a href="%1$s" %2$s>Polldaddy support</a> and tell them your rating usercode is %3$s', 'polldaddy' ), 'http://polldaddy.com/feedback/', 'target="_blank"', $this->rating_user_code ) . '<br />' . __( 'Also include the following information when contacting support to help us resolve your problem as quickly as possible:', 'polldaddy' ) . '';
+		echo "<ol>" . sprintf( __( 'Contact <a href="%1$s" %2$s>Crowdsignal support</a> and tell them your rating usercode is %3$s', 'polldaddy' ), 'https://crowdsignal.com/feedback/', 'target="_blank"', $this->rating_user_code ) . '<br />' . __( 'Also include the following information when contacting support to help us resolve your problem as quickly as possible:', 'polldaddy' ) . '';
 		echo "<ul><li> API Key: " . get_option( 'polldaddy_api_key' ) . "</li>";
 		echo "<li> ID Usercode: " . get_option( 'pd-usercode-' . $current_user->ID ) . "</li>";
 		echo "<li> pd-rating-usercode: " . get_option( 'pd-rating-usercode' ) . "</li>";

--- a/readme.txt
+++ b/readme.txt
@@ -1,19 +1,19 @@
-=== Polldaddy Polls & Ratings ===
+=== Crowdsignal Polls & Ratings ===
 Contributors: eoigal, mdawaffe, donncha, johnny5, panosktn
-Tags: polls, poll, polldaddy, wppolls, vote, polling, surveys, rate, rating, ratings
+Tags: crowdsignal, polls, poll, polldaddy, wppolls, vote, polling, surveys, rate, rating, ratings
 Requires at least: 3.3
 Tested up to: 4.9.4
 Stable tag: 2.0.37
 
-Create and manage Polldaddy polls and ratings from within WordPress.
+Create and manage Crowdsignal polls and ratings from within WordPress.
 
 == Description ==
 
-The Polldaddy Polls and Ratings plugin allows you to create and manage polls and ratings from within your WordPress dashboard. You can create polls, choose from 20 different styles for your polls, and view all results for your polls as they come in. All Polldaddy polls are fully customizable, you can set a close date for your poll, create multiple choice polls, choose whether to display the results or keep them private. You can also create your own custom style for your poll. You can even embed the polls you create on other websites. You can collect unlimited votes and create unlimited polls. The new ratings menu allows you to embed ratings into your posts, pages or comments. The rating editor allows you to fully customize your rating. You can also avail of the 'Top Rated' widget that will allow you to place the widget in your sidebar. This widget will show you the top rated posts, pages and comments today, this week and this month.
+The Crowdsignal Polls and Ratings plugin allows you to create and manage polls and ratings from within your WordPress dashboard. You can create polls, choose from 20 different styles for your polls, and view all results for your polls as they come in. All Crowdsignal polls are fully customizable, you can set a close date for your poll, create multiple choice polls, choose whether to display the results or keep them private. You can also create your own custom style for your poll. You can even embed the polls you create on other websites. You can collect unlimited votes and create unlimited polls. The new ratings menu allows you to embed ratings into your posts, pages or comments. The rating editor allows you to fully customize your rating. You can also avail of the 'Top Rated' widget that will allow you to place the widget in your sidebar. This widget will show you the top rated posts, pages and comments today, this week and this month.
 
-The Polldaddy plugin requires PHP 5.
+The Crowdsignal plugin requires PHP 5.
 
-Polldaddy Polls is currently available in the following languages:
+Crowdsignal Polls is currently available in the following languages:
 
 * Arabic
 * Bosnian
@@ -55,16 +55,16 @@ Polldaddy Polls is currently available in the following languages:
 
 Want to help translate the plugin or keep an existing translation up-to-date? Head on over to the [translation site](http://translate.wordpress.com/projects/polldaddy/plugin).
 
-Some strings are not translated when polls and surveys are embedded. You will have to translate them using a language pack on [Polldaddy.com](http://polldaddy.com/).
+Some strings are not translated when polls and surveys are embedded. You will have to translate them using a language pack on [Crowdsignal.com](https://crowdsignal.com/).
 
 Development of the plugin will take place in [this Github repository](https://github.com/Automattic/polldaddy-plugin).
 
 == Installation ==
 
-Upload the plugin to your blog (or search for it and install it on your plugins page), activate it, then go to Settings->Polls to configure the plugin. You'll need a Polldaddy API key available from your [Polldaddy account page](http://polldaddy.com/account/#apikey) to sync your account and pull in your existing polls and ratings.
-Polldaddy.com is now linked to WordPress.com using [WordPress.com Connect](http://en.support.wordpress.com/wpcc-faq/) which means you can use your WordPress.com username and password to login to Polldaddy.com. If you have a WordPress.com account and have never used Polldaddy.com you can login [here](https://polldaddy.com/login/) to access Polldaddy.com.
+Upload the plugin to your blog (or search for it and install it on your plugins page), activate it, then go to Settings->Polls to configure the plugin. You'll need a Crowdsignal API key available from your [Crowdsignal account page](https://app.crowdsignal.com/account/#apikey) to sync your account and pull in your existing polls and ratings.
+Crowdsignal.com is now linked to WordPress.com using [WordPress.com Connect](http://en.support.wordpress.com/wpcc-faq/) which means you can use your WordPress.com username and password to login to Crowdsignal.com. If you have a WordPress.com account and have never used Crowdsignal.com you can login [here](https://app.crowdsignal.com/login/) to access Crowdsignal.com.
 
-You can find further help on our [support page](http://support.polldaddy.com/). If you have any problems please use the [support forum](http://wordpress.org/support/plugin/polldaddy). The plugin also logs activity to a file using the [WP Debug Logger](http://wordpress.org/extend/plugins/wp-debug-logger/) plugin which can be useful in determining the cause of a problem.
+You can find further help on our [support page](https://crowdsignal.com/support/). If you have any problems please use the [support forum](http://wordpress.org/support/plugin/polldaddy). The plugin also logs activity to a file using the [WP Debug Logger](http://wordpress.org/extend/plugins/wp-debug-logger/) plugin which can be useful in determining the cause of a problem.
 
 == Screenshots ==
 
@@ -83,11 +83,11 @@ The Polls & Ratings menus can now be found under the Feedbacks top level menu.
 
 = I have multiple authors on my blog?  What happens? =
 
-Each author that wants to create polls will need his or her own Polldaddy.com account.
+Each author that wants to create polls will need his or her own Crowdsignal.com account.
 
 = But, as an Administrator, can I edit my Authors' polls =
 
-Yes. You'll be able to edit the polls they create from your blog.  (You won't be able to edit any of their non-blog, personal polls they create through Polldaddy.com.)
+Yes. You'll be able to edit the polls they create from your blog.  (You won't be able to edit any of their non-blog, personal polls they create through Crowdsignal.com.)
 
 = Neat! Um... can my Authors edit MY blog polls? =
 
@@ -101,9 +101,9 @@ More info [here](http://codex.wordpress.org/Theme_Development#Plugin_API_Hooks)
 
 = My ratings are gone after I reinstalled the plugin. How do I get them back? =
 
-Login to your Polldaddy.com account and [view the ratings](https://polldaddy.com/dashboard/?content=rating) in your dashboard. You should see ratings named "blog name - " comments/posts/pages. You need the rating ID of each of those which is visible when you edit them. It's the number in the URL of your browser that looks like https://polldaddy.com/ratings/1234567/edit/. After you connect the plugin to your Polldaddy account go to Settings->Ratings and make sure the ratings are displayed on your posts/pages/comments as desired. You'll see a link at the bottom of the page saying, "Advanced Settings" that will toggle new configuration settings. One of those settings is "rating ID" which you should replace with the number you got from your Polldaddy account. Now save the changes and the ratings on your site will be updated.
+Login to your Crowdsignal.com account and [view the ratings](https://app.crowdsignal.com/dashboard/?content=rating) in your dashboard. You should see ratings named "blog name - " comments/posts/pages. You need the rating ID of each of those which is visible when you edit them. It's the number in the URL of your browser that looks like https://app.crowdsignal.com/ratings/1234567/edit/. After you connect the plugin to your Crowdsignal account go to Settings->Ratings and make sure the ratings are displayed on your posts/pages/comments as desired. You'll see a link at the bottom of the page saying, "Advanced Settings" that will toggle new configuration settings. One of those settings is "rating ID" which you should replace with the number you got from your Crowdsignal account. Now save the changes and the ratings on your site will be updated.
 
-= I cannot access my ratings settings, I am getting a "Sorry! There was an error creating your rating widget. Please contact Polldaddy support to fix this." message. =
+= I cannot access my ratings settings, I am getting a "Sorry! There was an error creating your rating widget. Please contact Crowdsignal support to fix this." message. =
 
 You need to select the synchronize ratings account in the WordPress options page at Settings->Polls & Ratings to make sure the ratings API key is valid.
 


### PR DESCRIPTION
As a part of pabtAt-B-p2 this PR updates all text references and links to Crowdsignal, including the plugin's name.

![screen shot 2018-09-19 at 12 17 52](https://user-images.githubusercontent.com/8056203/45747421-1ac8e800-bc06-11e8-8500-cecdb061620b.png)

# Testing

Verify settings' headers and messages now say `Crowdsignal` instead of `Polldaddy`.