### PR TITLE
Ensure regular expressions used in the plugin are compatible with PHP 7.3

### DIFF
--- a/polldaddy-client.php
+++ b/polldaddy-client.php
@@ -1080,7 +1080,7 @@ function polldaddy_email( $args = null, $id = null, $_require_data = true ) {
 		}
 
 		// Check email is an email address
-		if ( preg_match( '/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/i', $args['address'], $matches ) == 0 )
+		if ( preg_match( '/^[A-Z0-9_%\.\+\-]+@[A-Z0-9\.\-]+\.[A-Z]{2,4}$/i', $args['address'], $matches ) == 0 )
 			return false;
 	}
 

--- a/polldaddy-org.php
+++ b/polldaddy-org.php
@@ -453,7 +453,7 @@ if ( !function_exists( 'wp_strip_all_tags' ) ) {
 		$string = strip_tags($string);
 
 		if ( $remove_breaks )
-			$string = preg_replace('/[\r\n\t ]+/', ' ', $string);
+			$string = preg_replace('/[\r\n\t\s]+/', ' ', $string);
 
 		return trim($string);
 	}


### PR DESCRIPTION
PHP's PCRE extension has been updated to version PCRE2 with the release of PHP 7.3 ([#](http://php.net/manual/en/migration73.other-changes.php#migration73.other-changes.pcre)).  
The new version is more strict when it comes to parsing regular expressions ([#](https://www.codementor.io/anastasionico/deprecations-and-changes-for-php-7-3-avoid-errors-poudese8o#pcre-to-pcre2-migration)) and so I took the following measures to ensure our plugin remains compatible:

- Hypens - `-` - **need** to be escaped when used as a character within a character class.
- For good measure, I made sure other *special* characters in character classes such as `.` or `+` are escaped as well.
- Updated whitespace to `\s` for improved clarity.

This change should not affect any functionality.