### PR TITLE
Fix popup buttons for survey & quiz shortcodes

### DIFF
--- a/polldaddy-shortcode.php
+++ b/polldaddy-shortcode.php
@@ -42,15 +42,15 @@ CONTAINER;
 		$include = $this->compress_it( $include );
 
 		$placeholder = '<div class="cs-embed pd-embed" data-settings="'.esc_attr( json_encode( $settings ) ).'"></div>';
-		if ( $type === 'button' )
-			$placeholder = '<a class="cs-embed pd-embed" href="'.esc_attr( $survey_link ).'" data-settings="'.esc_attr( json_encode( $settings ) ).'">'.esc_html( $settings['title'] ).'</a>';
+		if ( $settings['type'] === 'button' )
+			$placeholder = '<a class="cs-embed pd-embed" href="https://survey.fm/'.esc_attr( $settings['id'] ).'" data-settings="'.esc_attr( json_encode( $settings ) ).'">'.esc_html( $settings['title'] ).'</a>';
 
 		$js_include = $placeholder."\n";
 		$js_include .= '<script type="text/javascript"><!--//--><![CDATA[//><!--'."\n";
 		$js_include .= $include."\n";
 		$js_include .= "//--><!]]></script>\n";
 
-		if ( $type !== 'button' )
+		if ( $settings['type'] !== 'button' )
 			$js_include .= '<noscript>'.$survey_link."</noscript>\n";
 
 		return $js_include;


### PR DESCRIPTION
This PR takes care of an *undefined variable '$type'* PHP notice caused by survey and quiz embeds.  
It also fixes the link for 'popup' buttons from survey/quiz shortcodes.

# Testing

- Embed any quiz or survey using a shortcode, there should be no `undefined variable: $type` notice.
- Embed a quiz or survey as a 'popup' using a shortcode ( `type="button"` ). A popup should render an embedded quiz or survey correctly after clicking on the link.