### PR TITLE
Update poll results to display decimal numbers

### DIFF
--- a/polldaddy.php
+++ b/polldaddy.php
@@ -2574,7 +2574,7 @@ src="https://static.polldaddy.com/p/<?php echo (int) $poll_id; ?>.js"&gt;&lt;/sc
 						<?php echo number_format_i18n( $answer->_total ); ?>
 					</td>
 					<td style="text-align:center;vertical-align:middle;">
-						<?php echo number_format_i18n( $answer->_percent ); ?>%
+						<?php echo number_format_i18n( $answer->_percent, 2 ); ?>%
 					</td>
 					<td style="vertical-align:middle;">
 						<span class="result-bar" style="width: <?php echo number_format( $answer->_percent, 2 ); ?>%;">&nbsp;</span>


### PR DESCRIPTION
This patch updates the poll results page to display the percentages with two decimals like it's done in Crowdsignal's dashboard in order to improve consistency.

![screen shot 2019-01-30 at 21 51 55](https://user-images.githubusercontent.com/8056203/52011860-63a87b80-24d9-11e9-91a4-7b48f7dbda5f.png)

# Testing

- Create a poll and make a few votes
- Open WP Admin and go to Feedback > Polls and click 'Results' under the poll you created
- The percentages for each of the answers should be displayed with two decimals